### PR TITLE
fix missing session initialization in stdio transport mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+2026-04-15 - v1.1.1
+
+* FIX: Fixed missing session initialization in stdio transport mode
+
 2025-11-12 - v1.1.0
 
 * ENH: Added HTTP as transport protocol (MCP SSE Server Transport)

--- a/mcp_ckan_server.py
+++ b/mcp_ckan_server.py
@@ -604,6 +604,8 @@ def main(host: str,port: int, transport: str,logpath:str,loglevel:str):
             from mcp.server.stdio import stdio_server
 
             async def arun():
+                if not ckan_client.session:
+                    await ckan_client.__aenter__()
                 async with stdio_server() as streams:
                     await app.run(streams[0], streams[1],                 InitializationOptions(
                     server_name="ckan-mcp-server",


### PR DESCRIPTION
Fix error reported in https://github.com/ondics/ckan-mcp-server/issues/4